### PR TITLE
Request selected properties only

### DIFF
--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -88,12 +88,10 @@ class HubspotStream(RESTStream):
         return params
     
     def get_selected_properties(self) -> List[dict]:
-        selected = []
-        for key, value in self.metadata.items():
-            if(value.selected and len(key) > 0):
-                selected.append(key[-1])
-        
-        return selected
+        return [
+            key[-1] for key, value in self.metadata.items()
+            if value.selected and len(key) > 0
+            ]
 
     def prepare_request_payload(
         self, context: Optional[dict], next_page_token: Optional[Any]

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -86,6 +86,14 @@ class HubspotStream(RESTStream):
             params["after"] = next_page_token
         params["limit"] = 100
         return params
+    
+    def get_selected_properties(self) -> List[dict]:
+        selected = []
+        for key, value in self.metadata.items():
+            if(value.selected and len(key) > 0):
+                selected.append(key[-1])
+        
+        return selected
 
     def prepare_request_payload(
         self, context: Optional[dict], next_page_token: Optional[Any]

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -88,10 +88,11 @@ class HubspotStream(RESTStream):
         return params
     
     def get_selected_properties(self) -> List[dict]:
-        return [
+        selected_properties = [
             key[-1] for key, value in self.metadata.items()
             if value.selected and len(key) > 0
             ]
+        return list(set(self.properties).intersection(selected_properties))
 
     def prepare_request_payload(
         self, context: Optional[dict], next_page_token: Optional[Any]

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -17,11 +17,23 @@ class MeetingsStream(HubspotStream):
     path = "/crm/v3/objects/meetings"
     primary_keys = ["id"]
 
+    def get_selected_properties(self) -> List[dict]:
+        selected = []
+        for key, value in self.metadata.items():
+            if(len(key) > 0):
+                self.logger.info(key[-1])
+            if(value.selected and len(key) > 0):
+                selected.append(key[-1])
+        
+        return selected
+
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
+        selected_properties = self.get_selected_properties()
+        hub_properties = list(set(self.properties).intersection(selected_properties))
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(self.properties)
+        params["properties"] = ",".join(hub_properties)
         return params
 
     @property
@@ -36,11 +48,23 @@ class CallsStream(HubspotStream):
     path = "/crm/v3/objects/calls"
     primary_keys = ["id"]
 
+    def get_selected_properties(self) -> List[dict]:
+        selected = []
+        for key, value in self.metadata.items():
+            if(len(key) > 0):
+                self.logger.info(key[-1])
+            if(value.selected and len(key) > 0):
+                selected.append(key[-1])
+        
+        return selected
+
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
+        selected_properties = self.get_selected_properties()
+        hub_properties = list(set(self.properties).intersection(selected_properties))
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(self.properties)
+        params["properties"] = ",".join(hub_properties)
         return params
 
     @property
@@ -89,7 +113,6 @@ class CompaniesStream(HubspotStream):
     ) -> Dict[str, Any]:
         selected_properties = self.get_selected_properties()
         hub_properties = list(set(self.properties).intersection(selected_properties))
-
         params = super().get_url_params(context, next_page_token)
         params["properties"] = ",".join(hub_properties)
         params["archived"] = context["archived"]
@@ -114,11 +137,23 @@ class DealsStream(HubspotStream):
     primary_keys = ["id"]
     partitions = [{"archived": True}, {"archived": False}]
 
+    def get_selected_properties(self) -> List[dict]:
+        selected = []
+        for key, value in self.metadata.items():
+            if(len(key) > 0):
+                self.logger.info(key[-1])
+            if(value.selected and len(key) > 0):
+                selected.append(key[-1])
+        
+        return selected
+
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
+        selected_properties = self.get_selected_properties()
+        hub_properties = list(set(self.properties).intersection(selected_properties))
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(self.properties)
+        params["properties"] = ",".join(hub_properties)
         params["archived"] = context["archived"]
         params["associations"] = ",".join(HUBSPOT_OBJECTS)
         return params
@@ -145,11 +180,23 @@ class ContactsStream(HubspotStream):
     primary_keys = ["id"]
     partitions = [{"archived": True}, {"archived": False}]
 
+    def get_selected_properties(self) -> List[dict]:
+        selected = []
+        for key, value in self.metadata.items():
+            if(len(key) > 0):
+                self.logger.info(key[-1])
+            if(value.selected and len(key) > 0):
+                selected.append(key[-1])
+        
+        return selected
+
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
+        selected_properties = self.get_selected_properties()
+        hub_properties = list(set(self.properties).intersection(selected_properties))
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(self.properties)
+        params["properties"] = ",".join(hub_properties)
         params["archived"] = context["archived"]
         params["associations"] = ",".join(HUBSPOT_OBJECTS)
         return params
@@ -394,11 +441,23 @@ class QuotesStream(HubspotStream):
     primary_keys = ["id"]
     partitions = [{"archived": True}, {"archived": False}]
 
+    def get_selected_properties(self) -> List[dict]:
+        selected = []
+        for key, value in self.metadata.items():
+            if(len(key) > 0):
+                self.logger.info(key[-1])
+            if(value.selected and len(key) > 0):
+                selected.append(key[-1])
+        
+        return selected
+
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
+        selected_properties = self.get_selected_properties()
+        hub_properties = list(set(self.properties).intersection(selected_properties))
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(self.properties)
+        params["properties"] = ",".join(hub_properties)
         params["archived"] = context["archived"]
         params["associations"] = ",".join(HUBSPOT_OBJECTS)
         return params
@@ -415,11 +474,23 @@ class LineItemsStream(HubspotStream):
     primary_keys = ["id"]
     partitions = [{"archived": True}, {"archived": False}]
 
+    def get_selected_properties(self) -> List[dict]:
+        selected = []
+        for key, value in self.metadata.items():
+            if(len(key) > 0):
+                self.logger.info(key[-1])
+            if(value.selected and len(key) > 0):
+                selected.append(key[-1])
+        
+        return selected
+
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
+        selected_properties = self.get_selected_properties()
+        hub_properties = list(set(self.properties).intersection(selected_properties))
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(self.properties)
+        params["properties"] = ",".join(hub_properties)
         params["archived"] = context["archived"]
         params["associations"] = ",".join(HUBSPOT_OBJECTS)
         return params

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -17,18 +17,10 @@ class MeetingsStream(HubspotStream):
     path = "/crm/v3/objects/meetings"
     primary_keys = ["id"]
 
-    def get_selected_properties(self) -> List[dict]:
-        selected = []
-        for key, value in self.metadata.items():
-            if(value.selected and len(key) > 0):
-                selected.append(key[-1])
-        
-        return selected
-
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        selected_properties = self.get_selected_properties()
+        selected_properties = super().get_selected_properties()
         hub_properties = list(set(self.properties).intersection(selected_properties))
         params = super().get_url_params(context, next_page_token)
         params["properties"] = ",".join(hub_properties)
@@ -46,18 +38,10 @@ class CallsStream(HubspotStream):
     path = "/crm/v3/objects/calls"
     primary_keys = ["id"]
 
-    def get_selected_properties(self) -> List[dict]:
-        selected = []
-        for key, value in self.metadata.items():
-            if(value.selected and len(key) > 0):
-                selected.append(key[-1])
-        
-        return selected
-
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        selected_properties = self.get_selected_properties()
+        selected_properties = super().get_selected_properties()
         hub_properties = list(set(self.properties).intersection(selected_properties))
         params = super().get_url_params(context, next_page_token)
         params["properties"] = ",".join(hub_properties)
@@ -92,20 +76,12 @@ class CompaniesStream(HubspotStream):
     path = "/crm/v3/objects/companies"
     primary_keys = ["id"]
     partitions = [{"archived": True}, {"archived": False}]
-    
-    def get_selected_properties(self) -> List[dict]:
-        selected = []
-        for key, value in self.metadata.items():
-            if(value.selected and len(key) > 0):
-                selected.append(key[-1])
-        
-        return selected
 
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        selected_properties = self.get_selected_properties()
+        selected_properties = super().get_selected_properties()
         hub_properties = list(set(self.properties).intersection(selected_properties))
         params = super().get_url_params(context, next_page_token)
         params["properties"] = ",".join(hub_properties)
@@ -131,18 +107,10 @@ class DealsStream(HubspotStream):
     primary_keys = ["id"]
     partitions = [{"archived": True}, {"archived": False}]
 
-    def get_selected_properties(self) -> List[dict]:
-        selected = []
-        for key, value in self.metadata.items():
-            if(value.selected and len(key) > 0):
-                selected.append(key[-1])
-        
-        return selected
-
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        selected_properties = self.get_selected_properties()
+        selected_properties = super().get_selected_properties()
         hub_properties = list(set(self.properties).intersection(selected_properties))
         params = super().get_url_params(context, next_page_token)
         params["properties"] = ",".join(hub_properties)
@@ -172,18 +140,10 @@ class ContactsStream(HubspotStream):
     primary_keys = ["id"]
     partitions = [{"archived": True}, {"archived": False}]
 
-    def get_selected_properties(self) -> List[dict]:
-        selected = []
-        for key, value in self.metadata.items():
-            if(value.selected and len(key) > 0):
-                selected.append(key[-1])
-        
-        return selected
-
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        selected_properties = self.get_selected_properties()
+        selected_properties = super().get_selected_properties()
         hub_properties = list(set(self.properties).intersection(selected_properties))
         params = super().get_url_params(context, next_page_token)
         params["properties"] = ",".join(hub_properties)
@@ -431,18 +391,10 @@ class QuotesStream(HubspotStream):
     primary_keys = ["id"]
     partitions = [{"archived": True}, {"archived": False}]
 
-    def get_selected_properties(self) -> List[dict]:
-        selected = []
-        for key, value in self.metadata.items():
-            if(value.selected and len(key) > 0):
-                selected.append(key[-1])
-        
-        return selected
-
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        selected_properties = self.get_selected_properties()
+        selected_properties = super().get_selected_properties()
         hub_properties = list(set(self.properties).intersection(selected_properties))
         params = super().get_url_params(context, next_page_token)
         params["properties"] = ",".join(hub_properties)
@@ -462,18 +414,10 @@ class LineItemsStream(HubspotStream):
     primary_keys = ["id"]
     partitions = [{"archived": True}, {"archived": False}]
 
-    def get_selected_properties(self) -> List[dict]:
-        selected = []
-        for key, value in self.metadata.items():
-            if(value.selected and len(key) > 0):
-                selected.append(key[-1])
-        
-        return selected
-
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        selected_properties = self.get_selected_properties()
+        selected_properties = super().get_selected_properties()
         hub_properties = list(set(self.properties).intersection(selected_properties))
         params = super().get_url_params(context, next_page_token)
         params["properties"] = ",".join(hub_properties)

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -20,8 +20,6 @@ class MeetingsStream(HubspotStream):
     def get_selected_properties(self) -> List[dict]:
         selected = []
         for key, value in self.metadata.items():
-            if(len(key) > 0):
-                self.logger.info(key[-1])
             if(value.selected and len(key) > 0):
                 selected.append(key[-1])
         
@@ -51,8 +49,6 @@ class CallsStream(HubspotStream):
     def get_selected_properties(self) -> List[dict]:
         selected = []
         for key, value in self.metadata.items():
-            if(len(key) > 0):
-                self.logger.info(key[-1])
             if(value.selected and len(key) > 0):
                 selected.append(key[-1])
         
@@ -100,8 +96,6 @@ class CompaniesStream(HubspotStream):
     def get_selected_properties(self) -> List[dict]:
         selected = []
         for key, value in self.metadata.items():
-            if(len(key) > 0):
-                self.logger.info(key[-1])
             if(value.selected and len(key) > 0):
                 selected.append(key[-1])
         
@@ -140,8 +134,6 @@ class DealsStream(HubspotStream):
     def get_selected_properties(self) -> List[dict]:
         selected = []
         for key, value in self.metadata.items():
-            if(len(key) > 0):
-                self.logger.info(key[-1])
             if(value.selected and len(key) > 0):
                 selected.append(key[-1])
         
@@ -183,8 +175,6 @@ class ContactsStream(HubspotStream):
     def get_selected_properties(self) -> List[dict]:
         selected = []
         for key, value in self.metadata.items():
-            if(len(key) > 0):
-                self.logger.info(key[-1])
             if(value.selected and len(key) > 0):
                 selected.append(key[-1])
         
@@ -444,8 +434,6 @@ class QuotesStream(HubspotStream):
     def get_selected_properties(self) -> List[dict]:
         selected = []
         for key, value in self.metadata.items():
-            if(len(key) > 0):
-                self.logger.info(key[-1])
             if(value.selected and len(key) > 0):
                 selected.append(key[-1])
         
@@ -477,8 +465,6 @@ class LineItemsStream(HubspotStream):
     def get_selected_properties(self) -> List[dict]:
         selected = []
         for key, value in self.metadata.items():
-            if(len(key) > 0):
-                self.logger.info(key[-1])
             if(value.selected and len(key) > 0):
                 selected.append(key[-1])
         

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -20,10 +20,9 @@ class MeetingsStream(HubspotStream):
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        selected_properties = super().get_selected_properties()
-        hub_properties = list(set(self.properties).intersection(selected_properties))
+        selected_properties = self.get_selected_properties()
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(hub_properties)
+        params["properties"] = ",".join(selected_properties)
         return params
 
     @property
@@ -41,10 +40,9 @@ class CallsStream(HubspotStream):
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        selected_properties = super().get_selected_properties()
-        hub_properties = list(set(self.properties).intersection(selected_properties))
+        selected_properties = self.get_selected_properties()
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(hub_properties)
+        params["properties"] = ",".join(selected_properties)
         return params
 
     @property
@@ -81,10 +79,9 @@ class CompaniesStream(HubspotStream):
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        selected_properties = super().get_selected_properties()
-        hub_properties = list(set(self.properties).intersection(selected_properties))
+        selected_properties = self.get_selected_properties()
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(hub_properties)
+        params["properties"] = ",".join(selected_properties)
         params["archived"] = context["archived"]
         params["associations"] = ",".join(HUBSPOT_OBJECTS)
         return params
@@ -110,10 +107,9 @@ class DealsStream(HubspotStream):
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        selected_properties = super().get_selected_properties()
-        hub_properties = list(set(self.properties).intersection(selected_properties))
+        selected_properties = self.get_selected_properties()
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(hub_properties)
+        params["properties"] = ",".join(selected_properties)
         params["archived"] = context["archived"]
         params["associations"] = ",".join(HUBSPOT_OBJECTS)
         return params
@@ -143,10 +139,9 @@ class ContactsStream(HubspotStream):
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        selected_properties = super().get_selected_properties()
-        hub_properties = list(set(self.properties).intersection(selected_properties))
+        selected_properties = self.get_selected_properties()
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(hub_properties)
+        params["properties"] = ",".join(selected_properties)
         params["archived"] = context["archived"]
         params["associations"] = ",".join(HUBSPOT_OBJECTS)
         return params
@@ -394,10 +389,9 @@ class QuotesStream(HubspotStream):
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        selected_properties = super().get_selected_properties()
-        hub_properties = list(set(self.properties).intersection(selected_properties))
+        selected_properties = self.get_selected_properties()
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(hub_properties)
+        params["properties"] = ",".join(selected_properties)
         params["archived"] = context["archived"]
         params["associations"] = ",".join(HUBSPOT_OBJECTS)
         return params
@@ -417,10 +411,9 @@ class LineItemsStream(HubspotStream):
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        selected_properties = super().get_selected_properties()
-        hub_properties = list(set(self.properties).intersection(selected_properties))
+        selected_properties = self.get_selected_properties()
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(hub_properties)
+        params["properties"] = ",".join(selected_properties)
         params["archived"] = context["archived"]
         params["associations"] = ",".join(HUBSPOT_OBJECTS)
         return params

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -72,12 +72,26 @@ class CompaniesStream(HubspotStream):
     path = "/crm/v3/objects/companies"
     primary_keys = ["id"]
     partitions = [{"archived": True}, {"archived": False}]
+    
+    def get_selected_properties(self) -> List[dict]:
+        selected = []
+        for key, value in self.metadata.items():
+            if(len(key) > 0):
+                self.logger.info(key[-1])
+            if(value.selected and len(key) > 0):
+                selected.append(key[-1])
+        
+        return selected
+
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
+        selected_properties = self.get_selected_properties()
+        hub_properties = list(set(self.properties).intersection(selected_properties))
+
         params = super().get_url_params(context, next_page_token)
-        params["properties"] = ",".join(self.properties)
+        params["properties"] = ",".join(hub_properties)
         params["archived"] = context["archived"]
         params["associations"] = ",".join(HUBSPOT_OBJECTS)
         return params


### PR DESCRIPTION
# What was the issue
All properties for a parent object were being requested, regardless of the `select` configuration. For objects with a large property set, this meant Hubspot was returning a 414. Please see GitHub issue [here](https://github.com/potloc/tap-hubspot/issues/93).

# How did we solve it
Requesting only the properties that have been selected.

# Additional Notes / Warnings


# Fun fact (optional)
The Postman Hubspot collection was really useful to debug this kind of issue ✨ 
